### PR TITLE
fix #73: Make PMS_DEBUG thread safe

### DIFF
--- a/ecs/src/nox/util/pms_debug.cpp
+++ b/ecs/src/nox/util/pms_debug.cpp
@@ -1,0 +1,2 @@
+#include <nox/util/pms_debug.h>
+std::mutex g_mutex;

--- a/ecs/src/nox/util/pms_debug.h
+++ b/ecs/src/nox/util/pms_debug.h
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <cstdarg>
 #include <exception>
+#include <mutex>
+
+extern std::mutex g_mutex;
 
 template<std::size_t sizeOfFileName>
 void
@@ -12,9 +15,10 @@ logDebug(const char(&filename)[sizeOfFileName],
          const char* fmt,
          ...)
 {
+    std::lock_guard<std::mutex> lock(g_mutex);
     const char* format = "[DEBUG] Function: %s Line: %i: Message: ";
-    std::printf(format, function, line);
 
+    std::printf(format, function, line);
     std::va_list args;
     va_start(args, fmt);
     std::vprintf(fmt, args);


### PR DESCRIPTION
Made the PMS_DEBUG macro thread safe, so it can still be used for fast
debug logging, even when used in a threaded environment.